### PR TITLE
ci: use Github Actions in parallel to Travis CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+---
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+  - cron: '35 4 * * 4'  # weekly on thursday morning
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+        - '2.5'
+        - '2.6'
+        - '2.7'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Install dependencies
+      run: |
+        bundle
+    - name: Test
+      run: |
+        bundle exec rake ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
 - 2.5
 
 script:
-- bundle exec rake travis
+- bundle exec rake ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openvpn-status-web
 
-[![Build Status](https://travis-ci.com/cmur2/openvpn-status-web.svg?branch=master)](https://travis-ci.com/cmur2/openvpn-status-web) [![Depfu](https://badges.depfu.com/badges/c264e2f70f2a19c43f880ddcb4a12ba8/overview.svg)](https://depfu.com/github/cmur2/openvpn-status-web?project_id=6194)
+[![Build Status](https://travis-ci.com/cmur2/openvpn-status-web.svg?branch=master)](https://travis-ci.com/cmur2/openvpn-status-web) ![ci](https://github.com/cmur2/openvpn-status-web/workflows/ci/badge.svg) [![Depfu](https://badges.depfu.com/badges/c264e2f70f2a19c43f880ddcb4a12ba8/overview.svg)](https://depfu.com/github/cmur2/openvpn-status-web?project_id=6194)
 
 ## Description
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,4 @@ end
 
 task default: [:rubocop, :spec, 'bundle:audit']
 
-task travis: [:default, :'solargraph:init', :'solargraph:tc']
+task ci: [:default, :'solargraph:init', :'solargraph:tc']


### PR DESCRIPTION
- this adds a new workflow for Github Actions that mirrors what the existing Travis CI workflow tests
- Travis CI might become unfriendly to opensource soonish so migration might be necessary